### PR TITLE
feat: Add actions column to Students and Teachers tables

### DIFF
--- a/frontend/src/screens/app/Students/Students/Students.tsx
+++ b/frontend/src/screens/app/Students/Students/Students.tsx
@@ -53,21 +53,40 @@ const Students = () => {
       header: "Correo",
       accessor: "email",
     },
+  ];
+
+  const actions = [
     {
+      permission: checkPermission(permissions, "STUDENT", "PUT"),
+      component: (id: string) => (
+        <IconButton onClick={() => navigation(`/home/teacher/edit/${id}`)}>
+          <Edit />
+        </IconButton>
+      ),
+    },
+    {
+      permission: checkPermission(permissions, "STUDENT", "DELETE"),
+      component: (id: string) => (
+        <IconButton onClick={() => handleModal(id)}>
+          <Delete />
+        </IconButton>
+      ),
+    },
+  ];
+
+  if (actions.some((action) => action.permission)) {
+    columns.push({
       header: "Actions",
       accessor: "_id",
       render: (id) => (
         <div>
-          <IconButton onClick={() => navigation(`/home/student/edit/${id}`)}>
-            <Edit />
-          </IconButton>
-          <IconButton onClick={() => handleModal(id)}>
-            <Delete />
-          </IconButton>
+          {actions.map((action) =>
+            action.permission ? action.component(id) : null
+          )}
         </div>
       ),
-    },
-  ];
+    });
+  }
 
   const tableLayoutProps = {
     title: "STUDENTS",

--- a/frontend/src/screens/app/Teachers/Teachers/Teachers.tsx
+++ b/frontend/src/screens/app/Teachers/Teachers/Teachers.tsx
@@ -60,21 +60,41 @@ const Teachers = () => {
         <span>{roles.includes("Coordinator") ? "Sí" : "No"}</span>
       ),
     },
+  ];
+
+  const actions = [
     {
+      permission: checkPermission(permissions, "TEACHER", "PUT"),
+      component: (id: string) => (
+        <IconButton onClick={() => navigation(`/home/teacher/edit/${id}`)}>
+          <Edit />
+        </IconButton>
+      ),
+    },
+    {
+      permission: checkPermission(permissions, "TEACHER", "DELETE"),
+      component: (id: string) => (
+        <IconButton onClick={() => handleModal(id)}>
+          <Delete />
+        </IconButton>
+      ),
+    },
+  ];
+
+  // Add the actions column if any permissions are granted
+  if (actions.some((action) => action.permission)) {
+    columns.push({
       header: "Actions",
       accessor: "_id",
       render: (id) => (
         <div>
-          <IconButton onClick={() => navigation(`/home/teacher/edit/${id}`)}>
-            <Edit />
-          </IconButton>
-          <IconButton onClick={() => handleModal(id)}>
-            <Delete />
-          </IconButton>
+          {actions.map((action) =>
+            action.permission ? action.component(id) : null
+          )}
         </div>
       ),
-    },
-  ];
+    });
+  }
 
   const tableLayoutProps = {
     title: "TEACHERS",


### PR DESCRIPTION
This commit adds an actions column to the Students and Teachers tables in the frontend. The actions column includes edit and delete buttons for each student and teacher, based on the user's permissions. The buttons are conditionally rendered based on the user's permission to edit or delete the respective entity. This enhancement improves the user experience by providing easy access to edit and delete functionality directly from the tables.