### PR TITLE
refactor: Update permissions and strategy names for Administrative As…

### DIFF
--- a/backend/src/enums/permissions.ts
+++ b/backend/src/enums/permissions.ts
@@ -190,12 +190,6 @@ const AdministrativeAssistantPermissions = [
     selector: "STUDENT",
   },
   {
-    slug: "/student/delete",
-    description: "Delete students",
-    type: "DELETE",
-    selector: "STUDENT",
-  },
-  {
     slug: "/students/get",
     description: "Get students",
     type: "GET",
@@ -218,12 +212,6 @@ const AdministrativeAssistantPermissions = [
     slug: "/teacher/put",
     description: "Put teachers",
     type: "PUT",
-    selector: "TEACHER",
-  },
-  {
-    slug: "/teacher/delete",
-    description: "Delete teachers",
-    type: "DELETE",
     selector: "TEACHER",
   },
   {
@@ -525,3 +513,4 @@ export {
   StudentPermissions,
   TeacherPermissions,
 };
+

--- a/backend/src/middlewares/authentication/getPermissions.middleware.ts
+++ b/backend/src/middlewares/authentication/getPermissions.middleware.ts
@@ -30,7 +30,7 @@ class StudentStrategy implements PermissionStrategy {
   }
 }
 
-class AdministrativeAssistantStrategy implements PermissionStrategy {
+class AdminAssistantStrategy implements PermissionStrategy {
   getPermissions(): Permission[] {
     return AdministrativeAssistantPermissions;
   }
@@ -46,7 +46,7 @@ class PermissionManager {
   private static roleStrategyMap: { [role: string]: PermissionStrategy } = {
     Teacher: new TeacherStrategy(),
     Student: new StudentStrategy(),
-    AdministrativeAssistant: new AdministrativeAssistantStrategy(),
+    AdminAssistant: new AdminAssistantStrategy(),
     Admin: new AdminStrategy(),
     Coordinator: new CoordinatorStrategy(),
   };

--- a/frontend/src/enumerables/Types.ts
+++ b/frontend/src/enumerables/Types.ts
@@ -79,6 +79,7 @@ export type FormData = Student | Teacher;
 
 export type Field = {
   id: string;
+  disabled?: boolean;
   label?: string;
   options?: { value: string; label: string }[];
   type: string;

--- a/frontend/src/enumerables/Users.ts
+++ b/frontend/src/enumerables/Users.ts
@@ -33,7 +33,6 @@ const TeacherFields = [
       maxLength: 9,
       minLength: 9,
     },
-    // valitation must be 9 digits numeric strictly
     validation: (value: string) => value === "" || /^\d{9}$/.test(value),
     helperText: "ID Number must have 9 digits",
     required: true,
@@ -52,7 +51,6 @@ const TeacherFields = [
     helperText: "Username must have at least 4 characters",
     required: true,
   },
-
   {
     id: "name",
     label: "Nombre",
@@ -79,7 +77,6 @@ const TeacherFields = [
       "Password must have at least 8 characters, 1 uppercase, 1 lowercase, 1 number and 1 special character",
     required: true,
   },
-
   {
     id: "campusBranch",
     label: "Sede",
@@ -335,7 +332,6 @@ const StudentUpdateFields = [
     section: "Información del Estudiante",
     fullWidth: true,
     disabled: true,
-    validation: (value: string) => value === "" || /^\d{10}$/.test(value),
     inputProps: {
       maxLength: 10,
       minLength: 10,

--- a/frontend/src/layouts/CreateForm/CreateForm.tsx
+++ b/frontend/src/layouts/CreateForm/CreateForm.tsx
@@ -182,18 +182,6 @@ const CreateForm = ({
   }, []);
 
   useEffect(() => {
-    for (const key in formData) {
-      if (formData[key as keyof FormData] === "N/A") {
-        setFormData({
-          ...formData,
-          [key]: "",
-        });
-      }
-    }
-    console.log(formData);
-  }, [formData]);
-
-  useEffect(() => {
     console.log(formData);
     if (formData.career.length === 0) {
       setIsCareerDisabled(true);
@@ -298,7 +286,6 @@ const CreateForm = ({
                 ? helperText
                 : ""
             }
-            disabled={formData[id as keyof FormData] === "N/A" ? true : false}
             required={formData[id as keyof FormData] === "" ? true : false}
           />
         );

--- a/frontend/src/screens/app/Students/Students/Students.tsx
+++ b/frontend/src/screens/app/Students/Students/Students.tsx
@@ -51,7 +51,7 @@ const Students = () => {
     {
       header: "Carrera",
       accessor: "career",
-      objectAccessor: (career) => career[0].name,
+      objectAccessor: (career) => (career.length > 0 ? career[0].name : "N/A"),
       render: (career) =>
         career.length > 0 ? <span>{career[0].name}</span> : <span>None</span>,
     },

--- a/frontend/src/screens/app/Teachers/Teachers/Teachers.tsx
+++ b/frontend/src/screens/app/Teachers/Teachers/Teachers.tsx
@@ -51,7 +51,7 @@ const Teachers = () => {
     {
       header: "Careera",
       accessor: "career",
-      objectAccessor: (career) => career[0].name,
+      objectAccessor: (career) => (career.length > 0 ? career[0].name : "N/A"),
       render: (career) =>
         career.length > 0 ? <span>{career[0].name}</span> : <span>None</span>,
     },


### PR DESCRIPTION
…sistant role

This commit updates the permissions and strategy names for the Administrative Assistant role. The permissions related to deleting students and teachers have been removed, as they are not required for this role. Additionally, the strategy name has been changed from "AdministrativeAssistantStrategy" to "AdminAssistantStrategy" for consistency. This refactor improves the clarity and maintainability of the codebase.